### PR TITLE
feat(CONTRIBUTING.md): update commit message text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Please follow the documentation guidelines listed below:
 
 ## Commit Messages
 
-All pull request commit messages are automatically checked using [GitCop] - this will inform you if there are any issues with your commit message and give you an opportunity to rectify any issues.
+We follow the [Conventional Commits] standard when creating commit subject lines and messages.
 
 The commit message lines should never exceed 72 characters and should be entered in the following format:
 
@@ -127,5 +127,5 @@ Do not include any copyright notices in any files committed to the repository. A
 [Fork]: https://help.github.com/en/github/getting-started-with-github/fork-a-repo
 [Unity project conventions]: https://github.com/ExtendRealityLtd/.github/blob/master/CONVENTIONS/UNITY3D.md
 [Unity documentation guidelines]: https://github.com/ExtendRealityLtd/Guidelines.Documentation
-[GitCop]: http://gitcop.com
+[Conventional Commits]: https://www.conventionalcommits.org/
 [GitHub Terms Of Service]: https://help.github.com/en/articles/github-terms-of-service#6-contributions-under-repository-license


### PR DESCRIPTION
The commit message text has been updated to reflect that
conventional commits are to be used and remove the GitCop
reference as it is no longer used.